### PR TITLE
Depersonalize Fluid blog - remove author-specific branding

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 site: Fluid
-title: Fluid - Tech Thoughts by Anbarasi U
+title: Fluid - Tech Thoughts
 tagline: Software engineering insights, web development explorations, and technology essays
-description: Technical writing and software engineering insights by Anbarasi U. Covering web development, programming concepts, technology trends, startups, philosophy, and innovative approaches to building digital products.
+description: Technical writing and software engineering insights. Covering web development, programming concepts, technology trends, startups, philosophy, and innovative approaches to building digital products.
 googlewebfonts: Fira+Code:wght@400;500;700
 lang: en-US
 timezone: Calcutta
@@ -10,28 +10,21 @@ google_analytics: true
 
 author:
   name: Anbarasi U
-  bio: Software engineer, writer, and creative technologist exploring ideas at the intersection of technology and thought
   email: hi@anbuu.in
   twitter: anbarasiu
 
 # Social media and SEO
 social:
-  name: Anbarasi U
+  name: Fluid
   links:
-    - https://github.com/anbarasiu
-    - https://twitter.com/anbarasiu
-    - https://anbuu.in
-    - https://lit.anbuu.in
     - https://fluid.anbuu.in
-    - https://gush.anbuu.in
-    - https://fable.anbuu.in
 
 twitter:
   username: anbarasiu
   card: summary_large_image
 
 # SEO keywords
-keywords: software engineering, web development, tech blog, programming, Anbarasi U, Anbu, Frankfurt developer, technology essays, startup insights, philosophy, creative technologist
+keywords: software engineering, web development, tech blog, programming, technology essays, startup insights, philosophy
 
 # Default images for social sharing
 defaults_image: /assets/img/fluid-og.jpg

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,10 +1,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="title" content="Thoughts et al by Anbarasi U">
+  <meta name="title" content="Fluid - Tech Thoughts">
   <meta name="description" content="Collection of thoughts, notes, tools and outcomes from tinkering on the web">
   <meta name="keywords" content="thoughts, tech, travel, philosophy, software engineering">
-  <meta name="author" content="Anbarasi U">
 
   
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/syntax.css">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,18 +14,6 @@ layout: compress
   "name": "{{ site.title }}",
   "description": "{{ site.description }}",
   "url": "{{ site.url }}",
-  "author": {
-    "@type": "Person",
-    "name": "{{ site.author.name }}",
-    "email": "{{ site.author.email }}",
-    "url": "https://anbuu.in",
-    "jobTitle": "Software Engineer",
-    "address": {
-      "@type": "PostalAddress",
-      "addressLocality": "Frankfurt",
-      "addressCountry": "Germany"
-    }
-  },
   "genre": ["Technology", "Software Engineering", "Web Development", "Programming", "Startups", "Philosophy"],
   "inLanguage": "en-US"
 }

--- a/about.html
+++ b/about.html
@@ -1,16 +1,15 @@
 ---
 layout: about
 title: About
-description: About Anbarasi U - Software engineer, writer, and creative technologist exploring ideas at the intersection of technology and thought
-keywords: Anbarasi U, Anbu, software engineer, tech writer, Frankfurt, web development, philosophy
+description: About Fluid - a technical blog exploring ideas at the intersection of technology and thought
+keywords: tech blog, web development, software engineering, philosophy
 ---
 
 <section>
     <h1>About Fluid</h1>
 
     <p>
-        Fluid is a technical blog by <strong>Anbarasi U</strong> (Anbu), a software engineer, poet, and writer based in Frankfurt, Germany.
-        This space explores the intersection of technology, engineering, philosophy, and creative thinking.
+        Fluid is a technical blog exploring the intersection of technology, engineering, philosophy, and creative thinking.
     </p>
 
     <h2>What You'll Find Here</h2>
@@ -24,27 +23,10 @@ keywords: Anbarasi U, Anbu, software engineer, tech writer, Frankfurt, web devel
         <li><strong>Books & Learning</strong>: Notes and reflections from technical books, papers, and continuous learning</li>
     </ul>
 
-    <h2>About the Author</h2>
-
-    <p>
-        Anbarasi U creates at the intersection of technology and creativity, maintaining multiple projects that explore
-        different facets of expression and thought:
-    </p>
-
-    <ul>
-        <li><strong><a href="https://lit.anbuu.in" target="_blank" rel="noopener">Lit</a></strong> - Poetry and literary verses</li>
-        <li><strong><a href="https://fluid.anbuu.in">Fluid</a></strong> - Tech thoughts and essays (you are here!)</li>
-        <li><strong><a href="https://gush.anbuu.in" target="_blank" rel="noopener">Gush</a></strong> - Writing inspiration prompts app</li>
-        <li><strong><a href="https://fable.anbuu.in" target="_blank" rel="noopener">Fable</a></strong> - German language learning with stories</li>
-    </ul>
-
     <h2>Get in Touch</h2>
 
     <p>
-        <strong>Email</strong>: <a href="mailto:hi@anbuu.in">hi@anbuu.in</a><br>
-        <strong>GitHub</strong>: <a href="https://github.com/anbarasiu" target="_blank" rel="noopener">@anbarasiu</a><br>
-        <strong>Twitter</strong>: <a href="https://twitter.com/anbarasiu" target="_blank" rel="noopener">@anbarasiu</a><br>
-        <strong>Main Site</strong>: <a href="https://anbuu.in" target="_blank" rel="noopener">anbuu.in</a>
+        <strong>Email</strong>: <a href="mailto:hi@anbuu.in">hi@anbuu.in</a>
     </p>
 
     <h2>About This Blog</h2>


### PR DESCRIPTION
## Summary
This PR removes personal author branding and references from the Fluid technical blog, transitioning it from a personal blog by Anbarasi U to a standalone technical publication. The changes focus on decoupling the blog's identity from the author's personal brand while maintaining its core technical content focus.

## Key Changes
- **Metadata updates**: Removed author name references from page titles, descriptions, and keywords across `about.html`, `_config.yml`, and `head.html`
- **About page restructuring**: Removed the "About the Author" section that listed the author's other projects (Lit, Gush, Fable) and simplified the introduction to focus solely on the blog itself
- **Contact information**: Simplified the "Get in Touch" section to only include email, removing GitHub, Twitter, and personal website links
- **Schema.org markup**: Removed the author Person object from the JSON-LD structured data in `_layouts/default.html`
- **Configuration cleanup**: Updated site title from "Fluid - Tech Thoughts by Anbarasi U" to "Fluid - Tech Thoughts" and removed author bio field
- **Social metadata**: Changed social media name from "Anbarasi U" to "Fluid" and removed links to personal projects and portfolio site

## Notable Details
- Author contact information (email, Twitter handle) is retained in config for potential future use, but removed from public-facing pages
- The blog's technical focus and content categories remain unchanged
- Keywords were simplified to remove personal identifiers while maintaining SEO relevance for the technical content

https://claude.ai/code/session_01EgJSHGQfuQgnTCWVKHuyAB